### PR TITLE
fix tenanttoken vs tenantToken

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function _agentOptions(options) {
     return {
         server:  credentials.communicationEndpoints ? credentials.communicationEndpoints.join(';') : _server(options),
         tenant: _tenant(options),
-        tenanttoken: credentials.tenanttoken,
+        tenanttoken: credentials.tenantToken || credentials.tenanttoken, //tenantToken comes from api, tenanttoken from cf-service
         // loglevelcon: 'none'
     }
 }


### PR DESCRIPTION
user can specify tenanttoken in the cf-service
if user defines apitoken in the cf-service, the response from the api is a tenantToken (with capital T)