### PR TITLE
OA-55589 always check TLS cert

### DIFF
--- a/lib/request-worker.js
+++ b/lib/request-worker.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { URL } = require('url');
 const https = require('https');
 const debug = require('debug')('dynatrace');
 
@@ -12,21 +11,9 @@ function writeResult(result) {
 	});
 }
 
-function isSecurityEnhancedDomain(url) {
-	const hostname = new URL(url).hostname;
-	return (hostname.endsWith('.dynatrace.com')) ||
-		(hostname.endsWith('.dynatracelabs.com')) ||
-		(hostname.endsWith('.ruxit.com')) ||
-		(hostname.endsWith('.ruxitlabs.com'));
-}
-
 function doRequest() {
 	debug(`child request, cmd size: ${reqData.length} bytes`);
 	const req = JSON.parse(reqData);
-
-	if (!isSecurityEnhancedDomain(req.url)) {
-		process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-	}
 
 	https.request(req.url, req.options, (res) => {
 		const response = {


### PR DESCRIPTION
The `process.env.NODE_TLS_REJECT_UNAUTHORIZED` disabling should not be based on the allow list in `isSecurityEnhancedDomain`.